### PR TITLE
Magnets added with a label have the label removed when magnet metadata is received

### DIFF
--- a/labelplus/core/core.py
+++ b/labelplus/core/core.py
@@ -730,7 +730,9 @@ class Core(CorePluginBase):
       label_id = self.__pending_labels.pop(torrent_id)
       self._set_torrent_label(torrent_id, label_id)
     else:
-      label_id = self._do_autolabel_torrent(torrent_id)
+      target_label_id = self._find_autolabel_match(torrent_id)
+      if target_label_id != labelplus.common.label.ID_NONE:
+        self._do_autolabel_torrent(torrent_id)
 
     if label_id != labelplus.common.label.ID_NONE:
       self._move_torrents([torrent_id])
@@ -751,6 +753,7 @@ class Core(CorePluginBase):
     if torrent_id in self.__pending_magnet_ids:
       self.on_torrent_added(torrent_id, False)
       self.__pending_magnet_ids.remove(torrent_id)
+
 
   @check_init
   def on_torrent_removed(self, torrent_id):


### PR DESCRIPTION
When on_torrent_added is executed and there is a pending label the label is set correctly. Unfortunately, when the recently added on_torrent_metadata_received is handled it calls on_torrent_added again. On this second call the autolabel value is used whether it is ID_NONE or not. The on_torrent_added handler was not originally designed to be called twice for the same torrent.

This PR makes it possible for it to be called twice. First time it'll use the pending label. Second time it'll use an autolabel only if it is not ID_NONE.